### PR TITLE
Another bad assert in transform removed

### DIFF
--- a/lib/src/common/transform.dart
+++ b/lib/src/common/transform.dart
@@ -109,7 +109,6 @@ class Transform {
 
   static void mulTransToOutUnsafeVec2(
       final Transform T, final Vector2 v, final Vector2 out) {
-    assert(v != out);
     final double px = v.x - T.p.x;
     final double py = v.y - T.p.y;
     out.x = (T.q.c * px + T.q.s * py);


### PR DESCRIPTION
The assert in mulTransToOutUnsafeVec2 does not make sense.  No reason to care if out vector is the same.