### PR TITLE
Remove C++ type function calls for viewport

### DIFF
--- a/lib/src/callbacks/debug_draw.dart
+++ b/lib/src/callbacks/debug_draw.dart
@@ -188,90 +188,47 @@ abstract class DebugDraw {
   }
 
   /**
-   * @param argScreen
-   * @param argWorld
-   */
-  void getScreenToWorldToOut(Vector2 argScreen, Vector2 argWorld) {
-    viewportTransform.getScreenToWorld(argScreen, argWorld);
-  }
-
-  /**
-   * @param argWorld
-   * @param argScreen
-   */
-  void getWorldToScreenToOut(Vector2 argWorld, Vector2 argScreen) {
-    viewportTransform.getWorldToScreen(argWorld, argScreen);
-  }
-
-  /**
-   * Takes the world coordinates and puts the corresponding screen coordinates in argScreen.
-   *
-   * @param worldX
-   * @param worldY
-   * @param argScreen
-   */
-  void getWorldToScreenToOutXY(
-      double worldX, double worldY, Vector2 argScreen) {
-    argScreen.setValues(worldX, worldY);
-    viewportTransform.getWorldToScreen(argScreen, argScreen);
-  }
-
-  /**
-   * takes the world coordinate (argWorld) and returns the screen coordinates.
-   *
-   * @param argWorld
-   */
-  Vector2 getWorldToScreen(Vector2 argWorld) {
-    Vector2 screen = new Vector2.zero();
-    viewportTransform.getWorldToScreen(argWorld, screen);
-    return screen;
-  }
-
-  /**
-   * Takes the world coordinates and returns the screen coordinates.
+   * Takes the world coordinates and returns the corresponding screen
+   * coordinates
    *
    * @param worldX
    * @param worldY
    */
-  Vector2 getWorldToScreenXY(double worldX, double worldY) {
-    Vector2 argScreen = new Vector2(worldX, worldY);
-    viewportTransform.getWorldToScreen(argScreen, argScreen);
-    return argScreen;
-  }
+  Vector2 getWorldToScreenToOutXY(double worldX, double worldY) =>
+    viewportTransform.getWorldToScreen(Vector2(worldX, worldY));
 
   /**
-   * takes the screen coordinates and puts the corresponding world coordinates in argWorld.
+   * Takes the world coordinate and returns the screen coordinates.
    *
-   * @param screenX
-   * @param screenY
    * @param argWorld
    */
-  void getScreenToWorldToOutXY(
-      double screenX, double screenY, Vector2 argWorld) {
-    argWorld.setValues(screenX, screenY);
-    viewportTransform.getScreenToWorld(argWorld, argWorld);
-  }
+  Vector2 getWorldToScreen(Vector2 argWorld) =>
+      viewportTransform.getWorldToScreen(argWorld);
+
+  /**
+   * Takes the world coordinates and returns the screen coordinates
+   *
+   * @param worldX
+   * @param worldY
+   */
+  Vector2 getWorldToScreenXY(double worldX, double worldY) =>
+      viewportTransform.getWorldToScreen(Vector2(worldX, worldY));
 
   /**
    * takes the screen coordinates (argScreen) and returns the world coordinates
    *
    * @param argScreen
    */
-  Vector2 getScreenToWorld(Vector2 argScreen) {
-    Vector2 world = new Vector2.zero();
-    viewportTransform.getScreenToWorld(argScreen, world);
-    return world;
-  }
+  Vector2 getScreenToWorld(Vector2 argScreen) =>
+      viewportTransform.getScreenToWorld(argScreen);
 
   /**
-   * takes the screen coordinates and returns the world coordinates.
+   * Takes the screen coordinates and returns the corresponding world
+   * coordinates
    *
    * @param screenX
    * @param screenY
    */
-  Vector2 getScreenToWorldXY(double screenX, double screenY) {
-    Vector2 screen = new Vector2(screenX, screenY);
-    viewportTransform.getScreenToWorld(screen, screen);
-    return screen;
-  }
+  Vector2 getScreenToWorldToOutXY(double screenX, double screenY) =>
+      viewportTransform.getScreenToWorld(Vector2(screenX, screenY));
 }

--- a/lib/src/collision/broadphase/dynamic_tree.dart
+++ b/lib/src/collision/broadphase/dynamic_tree.dart
@@ -841,7 +841,6 @@ class DynamicTree implements BroadPhaseStrategy {
   }
 
   final Color3i _color = Color3i.zero();
-  final Vector2 _textVec = Vector2.zero();
 
   void drawTreeX(
       DebugDraw argDraw, DynamicTreeNode node, int spot, int height) {
@@ -851,11 +850,11 @@ class DynamicTree implements BroadPhaseStrategy {
         1.0, (height - spot) * 1.0 / height, (height - spot) * 1.0 / height);
     argDraw.drawPolygon(drawVecs, 4, _color);
 
-    argDraw
+    Vector2 textVec = argDraw
         .getViewportTranform()
-        .getWorldToScreen(node.aabb.upperBound, _textVec);
+        .getWorldToScreen(node.aabb.upperBound);
     argDraw.drawStringXY(
-        _textVec.x, _textVec.y, "$node.id-${(spot + 1)}/$height", _color);
+        textVec.x, textVec.y, "$node.id-${(spot + 1)}/$height", _color);
 
     if (node.child1 != null) {
       drawTreeX(argDraw, node.child1, spot + 1, height);

--- a/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
+++ b/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
@@ -764,7 +764,6 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
   }
 
   final Color3i _color = new Color3i.zero();
-  final Vector2 _textVec = new Vector2.zero();
 
   void drawTreeX(DebugDraw argDraw, int node, int spot, int height) {
     AABB a = _aabb[node];
@@ -774,9 +773,11 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
         1.0, (height - spot) * 1.0 / height, (height - spot) * 1.0 / height);
     argDraw.drawPolygon(drawVecs, 4, _color);
 
-    argDraw.getViewportTranform().getWorldToScreen(a.upperBound, _textVec);
+    Vector2 textVec = argDraw
+        .getViewportTranform()
+        .getWorldToScreen(a.upperBound);
     argDraw.drawStringXY(
-        _textVec.x, _textVec.y, "$node-${(spot + 1)}/$height", _color);
+        textVec.x, textVec.y, "$node-${(spot + 1)}/$height", _color);
 
     int c1 = _child1[node];
     int c2 = _child2[node];

--- a/lib/src/common/viewport_transform.dart
+++ b/lib/src/common/viewport_transform.dart
@@ -78,32 +78,27 @@ class ViewportTransform {
   }
 
   /**
-   * Takes the world coordinate (argWorld) puts the corresponding
-   * screen coordinate in argScreen.  It should be safe to give the
-   * same object as both parameters.
+   * Takes the world coordinates and return the corresponding screen coordinates
    */
-  void getWorldToScreen(Vector2 argWorld, Vector2 argScreen) {
+  Vector2 getWorldToScreen(Vector2 argWorld) {
     // Correct for canvas considering the upper-left corner, rather than the
     // center, to be the origin.
     double gridCorrectedX = (argWorld.x * scale) + extents.x;
     double gridCorrectedY = extents.y - (argWorld.y * scale);
 
-    Vector2 translationTemp = translation;
-    argScreen.setValues(gridCorrectedX + translationTemp.x,
-        gridCorrectedY + -translationTemp.y);
+    return Vector2(gridCorrectedX + translation.x,
+        gridCorrectedY + -translation.y);
   }
 
   /**
-   * Takes the screen coordinates (argScreen) and puts the
-   * corresponding world coordinates in argWorld. It should be safe
-   * to give the same object as both parameters.
+   * Takes the screen coordinates and return the corresponding world coordinates
    */
-  void getScreenToWorld(Vector2 argScreen, Vector2 argWorld) {
+  Vector2 getScreenToWorld(Vector2 argScreen) {
     double translationCorrectedX = argScreen.x - translation.x;
     double translationCorrectedY = argScreen.y + translation.y;
 
     double gridCorrectedX = (translationCorrectedX - extents.x) / scale;
     double gridCorrectedY = ((translationCorrectedY - extents.y) * -1) / scale;
-    argWorld.setValues(gridCorrectedX, gridCorrectedY);
+    return Vector2(gridCorrectedX, gridCorrectedY);
   }
 }


### PR DESCRIPTION
Since functions are not used in the same way in Dart and C++ I suggest that we start to refactor the C++ function type styles `void f(arg1, arg2)` into `arg2Type f(arg1)` which will be a lot less confusing to use from Dart.