### PR TITLE
Fix torque bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.4.6
+* Fix bug with torque not being modified from applyTorque
+
 ### 0.4.5
 * Fixing warnings and formatting
 

--- a/lib/src/dynamics/body.dart
+++ b/lib/src/dynamics/body.dart
@@ -419,7 +419,7 @@ class Body {
       setAwake(true);
     }
 
-    torque += torque;
+    _torque += torque;
   }
 
   /// Apply an impulse at a point. This immediately modifies the velocity. It also modifies the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: box2d_flame
-version: 0.4.5
+version: 0.4.6
 description: A Dart 2D physics engine, port from the Java version, works for Web/Flutter
 homepage: https://github.com/feroult/box2d.dart
 dependencies:


### PR DESCRIPTION
Fixes the bug reported in https://github.com/flame-engine/flame/issues/374
`applyTorque` was only modifying its local variable instead of `body._torque`.